### PR TITLE
Widen dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,18 +7,18 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-halo2curves = "0.1.0"
-ff = "0.13.0"
-itertools = "0.12.0"
-rand_core = "0.6.4"
-subtle = "2.5"
-serde = { version = "1.0", features = ["derive"] }
+halo2curves = "0"
+ff = "0"
+itertools = "0"
+rand_core = "0"
+subtle = "2"
+serde = { version = "1", features = ["derive"] }
 
 
 [dev-dependencies]
-rand_xorshift = "0.3"
-ark-std = { version = "0.4", features = ["print-trace"] }
-criterion = { version = "0.5", features = ["html_reports"] }
+rand_xorshift = "0"
+ark-std = { version = "0", features = ["print-trace"] }
+criterion = { version = "0", features = ["html_reports"] }
 
 [[bench]]
 name = "bench"


### PR DESCRIPTION
So it's easier for downstream users, like ceno, to keep transitive dependencies up to date.